### PR TITLE
Fix a bug where game crashes if you open armor

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -133,7 +133,7 @@ end
 
 function onGuiOpened(e)
     local player = game.players[e.player_index]
-    if player.opened and player.opened.name == "signal-splitter-combinator" then
+    if e.entity and player.opened and player.opened.name == "signal-splitter-combinator" then
         player.opened = nil 
         CloseGUI(player)
         


### PR DESCRIPTION
When the event for gui open comes in it has Item not entity if it is armor and no name property on player.opened. I tried to check for existence of name but all methods I tried failed.